### PR TITLE
Improve GPT-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,9 @@ funcaptcha_bin
 test/
 config.ini
 test.py
+
+#-----------------
+scripts/*
+!scripts/GPT-cli.py
+!scripts/cred.py.template
+!scripts/get_parent_id.py

--- a/scripts/GPT-cli.py
+++ b/scripts/GPT-cli.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+import asyncio
+import sys
+
+from re_gpt import ChatGPT
+
+# --- consts ---
+#session_token = "__Secure-next-auth.session-token here"
+#conversation_id = "conversation ID here"
+#parent_id = "parent ID here"
+#
+from cred import *
+session_token = creds('session_token')
+conversation_id = creds('conversation_id')
+#parent_id = creds('parent_id')
+from get_parent_id import *
+parent_id = get_parent_id()
+# --------------
+
+class tColor:
+    # "\033[38;2;181;76;210m" == rgb(181,76,210)
+    reset = '\033[0m'
+    red = '\033[91m'
+    green = '\033[92m'
+    yellow = '\033[93m'
+    blue = '\033[94m'
+    purple = '\033[38;2;181;76;210m'
+
+# If the Python version is 3.8 or higher and the platform is Windows, set the event loop policy
+if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+async def main():
+    # Create an asynchronous ChatGPT instance using the session token from the config file
+    async with ChatGPT(session_token=session_token) as chatgpt:
+        # Get user input for the chat prompt
+        #prompt = input("Enter your prompt: ")
+        prompt = input(f"{tColor.purple}You: {tColor.reset}\n")
+
+        # Continue the existing chat using conversation_id and parent_id
+        async_chat_stream = chatgpt.chat(
+            prompt, conversation_id=conversation_id, parent_id=parent_id
+        )
+
+        print(f"{tColor.green}ChatGPT: {tColor.reset}" ) 
+        reply = ""
+
+        # Iterate through the messages received from the chat and print it
+        async for message in async_chat_stream:
+            message = message["message"]["content"]["parts"][0]
+            print(message[len(reply) :], end='', flush=True)
+            reply = message
+    
+    print("")
+
+if __name__ == "__main__":
+    try:
+        while True:
+            # Run the asynchronous main function using asyncio.run()
+            asyncio.run(main())
+    except KeyboardInterrupt:
+        exit("")
+

--- a/scripts/cred.py.template
+++ b/scripts/cred.py.template
@@ -1,0 +1,8 @@
+Credentials = {
+    'session_token' : "__Secure-next-auth.session-token here",
+    'conversation_id' : "conversation ID here",
+    'parent_id' : "parent ID here"
+}
+
+def creds(cred):
+    return Credentials[cred]

--- a/scripts/get_parent_id.py
+++ b/scripts/get_parent_id.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import asyncio
+import sys
+
+from re_gpt import ChatGPT
+
+from cred import *
+
+conversation_id = creds('conversation_id')
+
+# Required for Windows compatibility with asyncio
+if sys.version_info >= (3, 8) and sys.platform.lower().startswith("win"):
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+def get_last_msg_id(chat):
+    """
+    Get the ID of the last message in the chat.
+
+    Args:
+        chat (dict): The chat data.
+
+    Returns:
+        str: The ID of the last message.
+    """
+    mapping = chat.get("mapping", {})
+    if not mapping:
+        return
+    last_msg_key = list(mapping)[-1]  # The key is the message ID
+    return last_msg_key
+
+
+async def main():
+    async with ChatGPT( session_token=creds('session_token') ) as chatgpt:
+            fetched_chat = await chatgpt.fetch_chat(conversation_id)
+            parent_id = get_last_msg_id(fetched_chat)
+            #print(f"'parent_id' of '{conversation_id}' is: {parent_id}")
+            #print(f"{parent_id}")
+            return parent_id
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+def get_parent_id():
+    return asyncio.run(main())


### PR DESCRIPTION
Fixed:
    - ChatGPT output was splitting words in new lines
Improved:
    - The output is more "gpt-like", typing letter by letter and faster
Added:
    - Colors
    - External file for credentials
    - Fluid conversation
To do:
    - Create an script to get credentials and write them to `cred.py`
    - Create a branch or another project to do the same with [perplexity.ai][https://www.perplexity.ai/] -> it searches on the web and also gives references, no account needed